### PR TITLE
chore: sync issue templates from meta-repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: A bug report
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+What is wrong and where.
+
+**Steps to reproduce**
+1.
+2.
+
+**Expected vs actual behavior**
+- Expected:
+- Actual:
+
+**Environment**
+- Tool version and branch:
+- EAR Tools dependencies versions and branches:
+- Other relevant python environment info:
+
+**Fix direction**
+Initial thoughts on the fix, or "to be discussed in comments." Target branch: `vX`.
+```

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report a bug or incorrect behavior
+title: "[Bug]: "
+labels: ["bug"]
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is wrong and where.
+      placeholder: Describe the issue and where it occurs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide steps to reproduce the issue.
+      placeholder: |
+        1. 
+        2.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected vs actual behavior
+      description: Describe the expected behavior and what actually happened.
+      placeholder: |
+        Expected:
+        - 
+
+        Actual:
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Provide relevant environment information.
+      placeholder: |
+        Tool version and branch:
+        EAR Tools dependencies versions and branches:
+        Other relevant python environment info:
+    validations:
+      required: false
+
+  - type: textarea
+    id: fix_direction
+    attributes:
+      label: Fix direction
+      description: Initial thoughts on the fix or indicate if it should be discussed in comments.
+      placeholder: |
+        Initial thoughts on the fix, or "to be discussed in comments."
+        Target branch: vX
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/epic-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-template.md
@@ -1,0 +1,23 @@
+---
+name: Epic template
+about: A major project or enhancement
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Goal**
+What this epic delivers and why it matters.
+
+**Context**
+Background, motivation, and scope boundaries.
+
+**Tasks / child issues**
+- [ ] #issue or description (add progressively if not yet defined)
+
+**Deliverables**
+What concrete outputs are expected at the end.
+
+**Dependencies / constraints**
+Cross-repo or external dependencies worth flagging early.

--- a/.github/ISSUE_TEMPLATE/epic_template.md
+++ b/.github/ISSUE_TEMPLATE/epic_template.md
@@ -1,0 +1,20 @@
+---
+name: Epic
+about: Track a large body of work that can be broken down into several features and smaller tasks
+---
+
+**Goal**
+What this epic delivers and why it matters.
+
+**Context**
+Background, motivation, and scope boundaries.
+
+**Tasks / child issues**
+- [ ] #issue or description (add progressively if not yet defined)
+- [ ] Untracked deliverable or output expected at the end (use for items that don't warrant their own issue)
+
+**Dependencies / constraints**
+Cross-repo or external dependencies worth flagging early.
+
+**Branch** *(if applicable)*
+`feature/xxx_vX`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: A new feature
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Goal**
+One or two sentences on what this feature achieves and why.
+
+**Context**
+What gap or limitation does this address? Any relevant background.
+
+**Design**
+High-level approach or constraints. Implementation details to be refined in comments.
+
+**Tasks**
+- [ ] ...
+
+**Acceptance criteria**
+- What does a complete implementation look like?
+
+**Dependencies / constraints**
+- Other tools, issues, or external factors this depends on.
+
+**Branch**
+`feature/xxx_vX`

--- a/.github/ISSUE_TEMPLATE/task-template.md
+++ b/.github/ISSUE_TEMPLATE/task-template.md
@@ -1,0 +1,23 @@
+---
+name: Task template
+about: A simple generic task
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Context**
+Brief description of the problem, need, or situation that motivates this task.
+
+**Acceptance criteria**
+- What does "done" look like?
+
+**Dependencies / constraints**
+- Any blockers, related issues, or technical constraints worth noting.
+
+**Notes**
+Any additional context. Proposed solutions or implementation directions go in the comments.
+
+**Branch**
+`task/xxx_vX`


### PR DESCRIPTION
Automated sync of issue templates from the meta-repo.

Opened by the `sync-issue-templates` workflow.